### PR TITLE
Change order of media options

### DIFF
--- a/app.lisp
+++ b/app.lisp
@@ -28,9 +28,10 @@
                                        (orientation-requested . "Orientation")
                                        (sides . "Sides")))
 (defvar *CUPS-OPTIONS* '((media .
-                          (("legal" . "legal")
+                          (("letter" . "letter")
                            ("a4" . "a4")
-                           ("letter" . "letter")))
+                           ("legal" . "legal")
+                           ))
                          (number-up .
                           (("1" . "")
                            ("2" . "2")


### PR DESCRIPTION
Currently paper size defaults to legal. I believe this change should change it so the default is letter as that tends to be what most people are printing. I would have liked to test my changes but i am unsure how to build/test the app without a readme. Thanks!